### PR TITLE
Fix piped server address string

### DIFF
--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -539,7 +539,7 @@ Function Reinstall-LTService{
     http://labtechconsulting.com
 #> 
     Param(
-        [string]$Server = (Get-LTServiceInfo).'Server Address' ,
+        [string]$Server = ((Get-LTServiceInfo).'Server Address' -split "|",0,"SimpleMatch" | select -First 1) ,
         [string]$Password = (Get-LTServiceInfo).ServerPassword ,
         [string]$LocationID = (Get-LTServiceInfo).LocationID   
     )


### PR DESCRIPTION
It will now only input the first server address at install time after the uninstall, but that will be again updated from the template on first checkin