### PR TITLE
Update For POSH2 Compatability

### DIFF
--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -18,7 +18,6 @@
   
 #>
 
-#requires -version 2
 if (-not ($PSVersionTable)) {Write-Output 'PS1 Detected. PowerShell Version 2.0 or higher is required.';return}
 if (-not ($PSVersionTable) -or $PSVersionTable.PSVersion.Major -lt 3 ) {Write-Verbose 'PS2 Detected. PowerShell Version 3.0 or higher may be required for full functionality'}
 

--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -18,9 +18,9 @@
   
 #>
 
-#requires -version 3
+#requires -version 2
 if (-not ($PSVersionTable)) {Write-Output 'PS1 Detected. PowerShell Version 2.0 or higher is required.';return}
-if (-not ($PSVersionTable) -or $PSVersionTable.PSVersion.Major -lt 3 ) {Write-Verbose 'PS2 Detected. PowerShell Version 3.0 or higher may be required for full functionality';return}
+if (-not ($PSVersionTable) -or $PSVersionTable.PSVersion.Major -lt 3 ) {Write-Verbose 'PS2 Detected. PowerShell Version 3.0 or higher may be required for full functionality'}
 
 #Module Version
 $ModuleVersion = "1.0"


### PR DESCRIPTION
Previous change would cause POSH2 to abort loading. Now POSH2 will be accepted.