### PR TITLE
POSH2/Parameter Patches

### DIFF
--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -700,7 +700,8 @@ Function Install-LTService{
                 Do {
                     Write-Host -NoNewline '.'
                     Start-Sleep 2
-                } until ($sw.elapsed -gt $timeout -or (Get-LTServiceInfo -EA 0 -Verbose:$False|Select-Object -Expand 'ID' -EA 0) -gt 1)
+		     $tmpLTSI = (Get-LTServiceInfo -EA 0 -Verbose:$False | Select-Object -Expand 'ID' -EA 0)
+                } until ($sw.elapsed -gt $timeout -or $tmpLTSI -gt 1)
                 Write-Verbose "Completed wait for LabTech Installation."
                 If ($Hide) {Hide-LTAddRemove}
             }#End Try
@@ -711,7 +712,7 @@ Function Install-LTService{
 
             $tmpLTSI = Get-LTServiceInfo -EA 0
             if (($tmpLTSI|Get-Member|Where {$_.Name -match 'ID'})) {
-	            if (($tmpLTSI|Select-Object -Expand 'ID' -EA 0) -gt 1) {
+	    	if (($tmpLTSI|Select-Object -Expand 'ID' -EA 0) -gt 1) {
                     Write-Host ""
                     Write-Output "LabTech has been installed successfully. Agent ID: $($tmpLTSI|Select-Object -Expand 'ID' -EA 0) LocationID: $($tmpLTSI|Select-Object -Expand 'LocationID' -EA 0)"
                     if ($Rename){

--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -455,7 +455,7 @@ Function Uninstall-LTService{
                             Write-Verbose "Unable to test version response from $($Svr)."
                             Continue
                         }
-                        $SVer = $SvrVer|select-string –pattern '(?<=[|]{6})[0-9]{3}\.[0-9]{3}'|foreach {$_.matches}|select -Expand value
+                        $SVer = $SvrVer|select-string -pattern '(?<=[|]{6})[0-9]{3}\.[0-9]{3}'|foreach {$_.matches}|select -Expand value
                         if ([System.Version]$SVer -ge [System.Version]'110.374') {
                             #New Style Download Link starting with LT11 Patch 13 - Direct Location Targeting is no longer available
 			    $installer = "$($Svr)/Labtech/Deployment.aspx?Probe=1&installType=msi&MSILocations=1"
@@ -665,7 +665,7 @@ Function Install-LTService{
 
             if ($OSVersion -gt 6.2){
                 try{
-                    Enable-WindowsOptionalFeature –Online –FeatureName "NetFx3" -All | Out-Null
+                    Enable-WindowsOptionalFeature -Online -FeatureName "NetFx3" -All | Out-Null
                 }
                 catch{
                     Write-Error "ERROR: .NET 3.5 install failed." -ErrorAction Continue
@@ -720,7 +720,7 @@ Function Install-LTService{
                             Write-Verbose "Unable to test version response from $($Svr)."
                             Continue
                         }
-                        $SVer = $SvrVer|select-string –pattern '(?<=[|]{6})[0-9]{3}\.[0-9]{3}'|foreach {$_.matches}|select -Expand value
+                        $SVer = $SvrVer|select-string -pattern '(?<=[|]{6})[0-9]{3}\.[0-9]{3}'|foreach {$_.matches}|select -Expand value
                         if ([System.Version]$SVer -ge [System.Version]'110.374') {
                             #New Style Download Link starting with LT11 Patch 13 - Direct Location Targeting is no longer available
                             $installer = "$($Svr)/Labtech/Deployment.aspx?Probe=1&installType=msi&MSILocations=1"
@@ -1554,10 +1554,10 @@ Function Get-LTProbeErrors {
         $errors = $errors -join ' ' -split ':::'
         foreach($Line in $Errors){
             $items = $Line -split "`t" -replace ' - ',''
-            $object = New-Object –TypeName PSObject
-            $object | Add-Member –MemberType NoteProperty –Name ServiceVersion –Value $items[0]
-            $object | Add-Member –MemberType NoteProperty –Name Timestamp –Value $([datetime]$items[1])
-            $object | Add-Member –MemberType NoteProperty –Name Message –Value $items[2]
+            $object = New-Object -TypeName PSObject
+            $object | Add-Member -MemberType NoteProperty -Name ServiceVersion -Value $items[0]
+            $object | Add-Member -MemberType NoteProperty -Name Timestamp -Value $([datetime]$items[1])
+            $object | Add-Member -MemberType NoteProperty -Name Message -Value $items[2]
             Write-Output $object
         }
     }

--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -32,7 +32,7 @@ if (-not ($PSVersionTable) -or $PSVersionTable.PSVersion.Major -lt 3 ) {Write-Ve
 if ((Get-WmiObject -Class Win32_OperatingSystem).OSArchitecture -eq '64-bit' -and [IntPtr]::Size -ne 8) {Write-Warning '32-bit Session detected on 64-bit OS. Must run in native environment.';return}
 
 #Module Version
-$ModuleVersion = "1.2"
+$ModuleVersion = "1.3"
 
 #Ignore SSL errors
 add-type @"

--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -458,7 +458,7 @@ Function Uninstall-LTService{
                         $SVer = $SvrVer|select-string –pattern '(?<=[|]{6})[0-9]{3}\.[0-9]{3}'|foreach {$_.matches}|select -Expand value
                         if ([System.Version]$SVer -ge [System.Version]'110.374') {
                             #New Style Download Link starting with LT11 Patch 13 - Direct Location Targeting is no longer available
-                            $installer = "$($Svr)/Labtech/Deployment.aspx?Probe=1&installType=msi&MSILocations=1"
+			    $installer = "$($Svr)/Labtech/Deployment.aspx?Probe=1&installType=msi&MSILocations=1"
                         } else {
                             #Original Generic Installer URL - Yes, these both reference Location 1 and are thus the same. Will it change in Patch 14? This section is now ready.
                             $installer = "$($Svr)/Labtech/Deployment.aspx?Probe=1&installType=msi&MSILocations=1"

--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -1752,3 +1752,4 @@ Function Rename-LTAddRemove{
 }#End Function Rename-LTAddRemove
 
 #endregion Functions
+

--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -10,7 +10,7 @@
     This is a set of commandlets to interface with the LabTech Agent v10.5 and v11.
 
 .NOTES
-    Version:        1.2
+    Version:        1.3
     Author:         Chris Taylor
     Website:        labtechconsulting.com
     Creation Date:  3/14/2016
@@ -22,6 +22,9 @@
     Update Date: 6/7/2017
     Purpose/Change: Updates to address 32-bit vs. 64-bit operations.
 
+    Update Date: 6/10/2017
+    Purpose/Change: Updates for pipeline input, support for multiple servers
+    
 #>
     
 #requires -version 2
@@ -697,8 +700,8 @@ Function Install-LTService{
                 Do {
                     Write-Host -NoNewline '.'
                     Start-Sleep 2
-                } until ($sw.elapsed -gt $timeout -or (Get-LTServiceInfo -EA 0|Select-Object -Expand 'ID' -EA 0) -gt 1)
-                Write-Verbose "Completed waiting for LabTech Installation."
+                } until ($sw.elapsed -gt $timeout -or (Get-LTServiceInfo -EA 0 -Verbose:$False|Select-Object -Expand 'ID' -EA 0) -gt 1)
+                Write-Verbose "Completed wait for LabTech Installation."
                 If ($Hide) {Hide-LTAddRemove}
             }#End Try
 


### PR DESCRIPTION
Some homework. :) 
These updates are to enable detection of the server version, as LT is changing the format for what URL's you can retrieve. It also addressed some parameter passing issues that I found (or introduced and solved), and has has the ReInstall/Uninstall/Install/Backup functions all tested on POSH2 and POSH5, with and without -Rename specified. Also some spelling changes, replacement of tabs with spaces, some sorting of the Reg Keys for uninstall, and other little things.