### PR TITLE
Resolve Get-LTServiceInfo breaking STOP response

### DIFF
--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -95,14 +95,15 @@ Function Get-LTServiceInfo{
         Clear-Variable key,BasePath,exclude,Servers -EA 0 -WhatIf:$False -Confirm:$False #Clearing Variables for use
         Write-Debug "Starting $($myInvocation.InvocationName)"
 
-        if ((Test-Path 'HKLM:\SOFTWARE\LabTech\Service') -eq $False){
-            Write-Error "ERROR: Unable to find information on LTSvc. Make sure the agent is installed." -ErrorAction Stop
-        }
         $exclude = "PSParentPath","PSChildName","PSDrive","PSProvider","PSPath"
         $key = $Null
     }#End Begin
 
     Process{
+        if ((Test-Path 'HKLM:\SOFTWARE\LabTech\Service') -eq $False){
+            Write-Error "ERROR: Unable to find information on LTSvc. Make sure the agent is installed."; Return $Null
+        }
+
         If ($PSCmdlet.ShouldProcess("LTService", "Retrieving Service Registry Values")) {
             Write-Verbose "Checking for LT Service registry keys."
             Try{

--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -1373,7 +1373,10 @@ Function Redo-LTService{
         }#End Catch
 
         Finally{
-            If ($WhatIfPreference -ne $True) {Start-Sleep 10}
+            If ($WhatIfPreference -ne $True) {
+                Write-Verbose "Waiting 20 seconds for prior uninstall to settle before starting Install."
+                Start-Sleep 20
+            }
         }
 
         Write-Verbose "Starting: Install-LTService -Server $($ServerList -join ',') $PasswordArg -LocationID $LocationID -Hide:`$$($Hide) $RenameArg"


### PR DESCRIPTION
Using "return" in the begin block doesn't stop the function, a hard stop will but that has to be trapped. Moving the test to the process {} block allows the Error Action to be controlled by the caller, and terminates the function successfully,