### PR TITLE
Updates to server regex pattern, formatting changes

### DIFF
--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -1246,7 +1246,7 @@ Function Install-LTService{
                         Write-Host -NoNewline '.'
                         Start-Sleep 5
                         $tmpLTSI = (Get-LTServiceInfo -EA 0 -Verbose:$False -WhatIf:$False -Confirm:$False -Debug:$False|Select-Object -Expand 'ID' -EA 0)
-                    } Until ($sw.elapsed -gt $timeout -or $tmpLTSI -gt 1)
+                    } Until ($sw.elapsed -gt $timeout -or $tmpLTSI -ge 1)
                     Write-Host ""
                     $sw.Stop()
                     Write-Verbose "Completed wait for LabTech Installation after $(([int32]$sw.Elapsed.TotalSeconds).ToString()) seconds."
@@ -1263,7 +1263,7 @@ Function Install-LTService{
             If ( $WhatIfPreference -ne $True ) {
                 $tmpLTSI = Get-LTServiceInfo -EA 0 -Verbose:$False -WhatIf:$False -Confirm:$False -Debug:$False
                 If (($tmpLTSI)) {
-                    If (($tmpLTSI|Select-Object -Expand 'ID' -EA 0) -gt 1) {
+                    If (($tmpLTSI|Select-Object -Expand 'ID' -EA 0) -ge 1) {
                         Write-Output "LabTech has been installed successfully. Agent ID: $($tmpLTSI|Select-Object -Expand 'ID' -EA 0) LocationID: $($tmpLTSI|Select-Object -Expand 'LocationID' -EA 0)"
                     } ElseIf (!($NoWait)) {
                         Write-Error "ERROR: Line $(LINENUM): LabTech installation completed but Agent failed to register within expected period." -ErrorAction Continue

--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -524,7 +524,7 @@ Function Uninstall-LTService{
     This will uninstall the LabTech agent using the provided server URL to download the uninstallers.
 
 .NOTES
-    Version:        1.6
+    Version:        1.7
     Author:         Chris Taylor
     Website:        labtechconsulting.com
     Creation Date:  3/14/2016
@@ -554,6 +554,10 @@ Function Uninstall-LTService{
     Update Date: 10/18/2018
     Purpose/Change: Added minimum size requirement for agent uninstaller exe to detect and skip a bad file download. 
     Uninstall will proceed even if the agent uninstaller exe cannot be downloaded.
+    
+    Update Date: 1/21/2019
+    Purpose/Change: Minor bugfixes/adjustments.
+    Allow single label server name.
 
 .LINK
     http://labtechconsulting.com
@@ -918,7 +922,7 @@ Function Install-LTService{
     This will install the LabTech agent using the provided Server URL, Password, and LocationID.
 
 .NOTES
-    Version:        1.8
+    Version:        1.9
     Author:         Chris Taylor
     Website:        labtechconsulting.com
     Creation Date:  3/14/2016
@@ -955,7 +959,11 @@ Function Install-LTService{
     Update Date: 6/5/2018
     Purpose/Change: Added -SkipDotNet parameter.
     Allows for skipping of .NET 3.5 and 2.0 framework checks for installing on OS with .NET 4.0+ already installed
-
+    
+    Update Date: 1/21/2019
+    Purpose/Change: Minor bugfixes/adjustments.
+    Allow single label server name, accept Agent ID 1 as valid.
+    
 .LINK
     http://labtechconsulting.com
 #> 
@@ -1492,245 +1500,249 @@ Function Redo-LTService{
 Set-Alias -Name ReInstall-LTService -Value Redo-LTService
 
 Function Update-LTService{
-    <#
-    .SYNOPSIS
-        This function will manually update the LabTech agent to the requested version.
+<#
+.SYNOPSIS
+    This function will manually update the LabTech agent to the requested version.
 
-    .DESCRIPTION
-        This script will attempt to pull current server settings from machine, then download and run the agent updater.
+.DESCRIPTION
+    This script will attempt to pull current server settings from machine, then download and run the agent updater.
 
 
-    .PARAMETER Version
-        This is the agent version to install. 
-        Example: 120.240
-        This is needed to download the update file. If omitted, the version advertised by the server will be used.
+.PARAMETER Version
+    This is the agent version to install. 
+    Example: 120.240
+    This is needed to download the update file. If omitted, the version advertised by the server will be used.
 
-    .EXAMPLE
-        Update-LTService -Version 120.240
-        This will update the Automate agent to the specific version requested, using the server address in the registry.
+.EXAMPLE
+    Update-LTService -Version 120.240
+    This will update the Automate agent to the specific version requested, using the server address in the registry.
 
-    .EXAMPLE
-        Update-LTService
-        This will update the Automate agent to the current version advertised, using the server address in the registry.
+.EXAMPLE
+    Update-LTService
+    This will update the Automate agent to the current version advertised, using the server address in the registry.
 
-    .NOTES
-        Version:        1.0
-        Author:         Darren White
-        Creation Date:  8/28/2018
-        Purpose/Change: Initial function development
+.NOTES
+    Version:        1.1
+    Author:         Darren White
+    Creation Date:  8/28/2018
+    Purpose/Change: Initial function development
 
-    .LINK
-        http://labtechconsulting.com
-    #> 
-        [CmdletBinding(SupportsShouldProcess=$True)]
-        Param(
-            [parameter(Position=0)]
-            [AllowNull()]
-            [string]$Version
-        )
+    Update Date: 1/21/2019
+    Purpose/Change: Minor bugfixes/adjustments.
+    Allow single label server name, accept less digits for Agent Minor version number
 
-        Begin{
-            Set-Alias -name LINENUM -value Get-CurrentLineNumber -WhatIf:$False -Confirm:$False
-            Write-Debug "Starting $($myInvocation.InvocationName) at line $(LINENUM)"
-            Clear-Variable Svr, GoodServer, Settings -EA 0 -WhatIf:$False -Confirm:$False #Clearing Variables for use
-            $Settings = Get-LTServiceInfo -EA 0 -Verbose:$False -WhatIf:$False -Confirm:$False
-            $updaterPath = [System.Environment]::ExpandEnvironmentVariables("%windir%\temp\_LTUpdate")
-            $xarg=@("/o""$updaterPath""","/y")
-            $uarg=@("""$updaterPath\Update.ini""")
-        }#End Begin
+.LINK
+    http://labtechconsulting.com
+#> 
+    [CmdletBinding(SupportsShouldProcess=$True)]
+    Param(
+        [parameter(Position=0)]
+        [AllowNull()]
+        [string]$Version
+    )
 
-        Process{
-            if (-not ($Server)){
-                If ($Settings){
-                  $Server = $Settings|Select-Object -Expand 'Server' -EA 0
-                }
+    Begin{
+        Set-Alias -name LINENUM -value Get-CurrentLineNumber -WhatIf:$False -Confirm:$False
+        Write-Debug "Starting $($myInvocation.InvocationName) at line $(LINENUM)"
+        Clear-Variable Svr, GoodServer, Settings -EA 0 -WhatIf:$False -Confirm:$False #Clearing Variables for use
+        $Settings = Get-LTServiceInfo -EA 0 -Verbose:$False -WhatIf:$False -Confirm:$False
+        $updaterPath = [System.Environment]::ExpandEnvironmentVariables("%windir%\temp\_LTUpdate")
+        $xarg=@("/o""$updaterPath""","/y")
+        $uarg=@("""$updaterPath\Update.ini""")
+    }#End Begin
+
+    Process{
+        if (-not ($Server)){
+            If ($Settings){
+                $Server = $Settings|Select-Object -Expand 'Server' -EA 0
             }
+        }
 
-            Foreach ($Svr in $Server) {
-                If (-not ($GoodServer)) {
-                    If ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]+(\.[a-z0-9][a-z0-9_-]*)*)$') {
-                        If ($Svr -notmatch 'https?://.+') {$Svr = "http://$($Svr)"}
-                        Try {
-                            $SvrVerCheck = "$($Svr)/Labtech/Agent.aspx"
-                            Write-Debug "Testing Server Response and Version: $SvrVerCheck"
-                            $SvrVer = $Script:LTServiceNetWebClient.DownloadString($SvrVerCheck)
-                            Write-Debug "Raw Response: $SvrVer"
-                            $SVer = $SvrVer|select-string -pattern '(?<=[|]{6})[0-9]{1,3}\.[0-9]{1,3}'|ForEach-Object {$_.matches}|Select-Object -Expand value -EA 0
-                            If ($Null -eq ($SVer)) {
-                                Write-Verbose "Unable to test version response from $($Svr)."
-                                Continue
-                            }
-                            If ($Version -match '[1-9][0-9]{2}\.[0-9]{3}') {
-                                $updater = "$($Svr)/Labtech/Updates/LabtechUpdate_$($Version).zip"
-                            } ElseIf ([System.Version]$SVer -ge [System.Version]'105.001') {
-                                $Version = $SVer
-                                Write-Verbose "Using detected version ($Version) from server: $($Svr)."
-                                $updater = "$($Svr)/Labtech/Updates/LabtechUpdate_$($Version).zip"
-                            }
+        Foreach ($Svr in $Server) {
+            If (-not ($GoodServer)) {
+                If ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]+(\.[a-z0-9][a-z0-9_-]*)*)$') {
+                    If ($Svr -notmatch 'https?://.+') {$Svr = "http://$($Svr)"}
+                    Try {
+                        $SvrVerCheck = "$($Svr)/Labtech/Agent.aspx"
+                        Write-Debug "Testing Server Response and Version: $SvrVerCheck"
+                        $SvrVer = $Script:LTServiceNetWebClient.DownloadString($SvrVerCheck)
+                        Write-Debug "Raw Response: $SvrVer"
+                        $SVer = $SvrVer|select-string -pattern '(?<=[|]{6})[0-9]{1,3}\.[0-9]{1,3}'|ForEach-Object {$_.matches}|Select-Object -Expand value -EA 0
+                        If ($Null -eq ($SVer)) {
+                            Write-Verbose "Unable to test version response from $($Svr)."
+                            Continue
+                        }
+                        If ($Version -match '[1-9][0-9]{2}\.[0-9]{1,3}') {
+                            $updater = "$($Svr)/Labtech/Updates/LabtechUpdate_$($Version).zip"
+                        } ElseIf ([System.Version]$SVer -ge [System.Version]'105.001') {
+                            $Version = $SVer
+                            Write-Verbose "Using detected version ($Version) from server: $($Svr)."
+                            $updater = "$($Svr)/Labtech/Updates/LabtechUpdate_$($Version).zip"
+                        }
 
-                            #Kill all running processes from $updaterPath
-                            if (Test-Path $updaterPath){
-                                $Executables = (Get-ChildItem $updaterPath -Filter *.exe -Recurse -ErrorAction SilentlyContinue|Select-Object -Expand FullName)
-                                if ($Executables) {
-                                    Write-Verbose "Terminating LabTech Processes from $($updaterPath) if found running: $(($Executables) -replace [Regex]::Escape($updaterPath),'' -replace '^\\','')"
-                                    Get-Process | Where-Object {$Executables -contains $_.Path } | ForEach-Object {
-                                        Write-Debug "Terminating Process $($_.ProcessName)"
-                                        $($_) | Stop-Process -Force -ErrorAction SilentlyContinue
-                                    }
+                        #Kill all running processes from $updaterPath
+                        if (Test-Path $updaterPath){
+                            $Executables = (Get-ChildItem $updaterPath -Filter *.exe -Recurse -ErrorAction SilentlyContinue|Select-Object -Expand FullName)
+                            if ($Executables) {
+                                Write-Verbose "Terminating LabTech Processes from $($updaterPath) if found running: $(($Executables) -replace [Regex]::Escape($updaterPath),'' -replace '^\\','')"
+                                Get-Process | Where-Object {$Executables -contains $_.Path } | ForEach-Object {
+                                    Write-Debug "Terminating Process $($_.ProcessName)"
+                                    $($_) | Stop-Process -Force -ErrorAction SilentlyContinue
                                 }
-                            }#End If
+                            }
+                        }#End If
 
-                            #Remove $updaterPath - Depth First Removal, First by purging files, then Removing Folders, to get as much removed as possible if complete removal fails
-                            @("$updaterPath") | foreach-object {
-                                If ((Test-Path "$($_)" -EA 0)) {
-                                    If ( $PSCmdlet.ShouldProcess("$($_)","Remove Folder") ) {
-                                        Write-Debug "Removing Folder: $($_)"
-                                        Try {
-                                            Get-ChildItem -Path $_ -Recurse -Force -ErrorAction SilentlyContinue | Where-Object { ($_.psiscontainer) } | foreach-object { Get-ChildItem -Path "$($_.FullName)" -EA 0 | Where-Object { -not ($_.psiscontainer) } | Remove-Item -Force -ErrorAction SilentlyContinue -Confirm:$False -WhatIf:$False }
-                                            Get-ChildItem -Path $_ -Recurse -Force -ErrorAction SilentlyContinue | Where-Object { ($_.psiscontainer) } | Sort-Object { $_.fullname.length } -Descending | Remove-Item -Force -ErrorAction SilentlyContinue -Recurse -Confirm:$False -WhatIf:$False
-                                            Remove-Item -Recurse -Force -Path $_ -ErrorAction SilentlyContinue -Confirm:$False -WhatIf:$False
-                                        } Catch {}
-                                    }#End If
+                        #Remove $updaterPath - Depth First Removal, First by purging files, then Removing Folders, to get as much removed as possible if complete removal fails
+                        @("$updaterPath") | foreach-object {
+                            If ((Test-Path "$($_)" -EA 0)) {
+                                If ( $PSCmdlet.ShouldProcess("$($_)","Remove Folder") ) {
+                                    Write-Debug "Removing Folder: $($_)"
+                                    Try {
+                                        Get-ChildItem -Path $_ -Recurse -Force -ErrorAction SilentlyContinue | Where-Object { ($_.psiscontainer) } | foreach-object { Get-ChildItem -Path "$($_.FullName)" -EA 0 | Where-Object { -not ($_.psiscontainer) } | Remove-Item -Force -ErrorAction SilentlyContinue -Confirm:$False -WhatIf:$False }
+                                        Get-ChildItem -Path $_ -Recurse -Force -ErrorAction SilentlyContinue | Where-Object { ($_.psiscontainer) } | Sort-Object { $_.fullname.length } -Descending | Remove-Item -Force -ErrorAction SilentlyContinue -Recurse -Confirm:$False -WhatIf:$False
+                                        Remove-Item -Recurse -Force -Path $_ -ErrorAction SilentlyContinue -Confirm:$False -WhatIf:$False
+                                    } Catch {}
                                 }#End If
-                            }#End Foreach-Object
-            
-                            Try {
-                                If (-not (Test-Path -PathType Container -Path "$updaterPath" )){
-                                    New-Item "$updaterPath" -type directory -ErrorAction SilentlyContinue | Out-Null
-                                }#End if
-                                $updaterTest = [System.Net.WebRequest]::Create($updater)
-                                If (($Script:LTProxy.Enabled) -eq $True) {
-                                    Write-Debug "Proxy Configuration Needed. Applying Proxy Settings to request."
-                                    $updaterTest.Proxy=$Script:LTWebProxy
-                                }#End If                        
-                                $updaterTest.KeepAlive=$False
-                                $updaterTest.ProtocolVersion = '1.0'
-                                $updaterResult = $updaterTest.GetResponse()
-                                $updaterTest.Abort()
-                                If ($updaterResult.StatusCode -ne 200) {
-                                    Write-Warning "Line $(LINENUM): Unable to download LabtechUpdate.exe version $Version from server $($Svr)."
-                                    Continue
-                                } Else {
-                                    If ( $PSCmdlet.ShouldProcess($updater, "DownloadFile") ) {
-                                        Write-Debug "Downloading LabtechUpdate.exe from $updater"
-                                        $Script:LTServiceNetWebClient.DownloadFile($updater,"$updaterPath\LabtechUpdate.exe")
-                                        If((Test-Path "$updaterPath\LabtechUpdate.exe") -and  !((Get-Item "$updaterPath\LabtechUpdate.exe" -EA 0).length/1KB -gt 1234)) {
-                                            Write-Warning "Line $(LINENUM): LabtechUpdate.exe size is below normal. Removing suspected corrupt file."
-                                            Remove-Item "$updaterPath\LabtechUpdate.exe" -ErrorAction SilentlyContinue -Force -Confirm:$False
-                                            Continue
-                                        }#End If
-                                    }#End If
+                            }#End If
+                        }#End Foreach-Object
         
-                                    If ($WhatIfPreference -eq $True) {
-                                        $GoodServer = $Svr
-                                    } ElseIf (Test-Path "$updaterPath\LabtechUpdate.exe") {
-                                        $GoodServer = $Svr
-                                        Write-Verbose "LabtechUpdate.exe downloaded successfully from server $($Svr)."
-                                    } Else {
-                                        Write-Warning "Line $(LINENUM): Error encountered downloading from $($Svr). No update file was received."
+                        Try {
+                            If (-not (Test-Path -PathType Container -Path "$updaterPath" )){
+                                New-Item "$updaterPath" -type directory -ErrorAction SilentlyContinue | Out-Null
+                            }#End if
+                            $updaterTest = [System.Net.WebRequest]::Create($updater)
+                            If (($Script:LTProxy.Enabled) -eq $True) {
+                                Write-Debug "Proxy Configuration Needed. Applying Proxy Settings to request."
+                                $updaterTest.Proxy=$Script:LTWebProxy
+                            }#End If                        
+                            $updaterTest.KeepAlive=$False
+                            $updaterTest.ProtocolVersion = '1.0'
+                            $updaterResult = $updaterTest.GetResponse()
+                            $updaterTest.Abort()
+                            If ($updaterResult.StatusCode -ne 200) {
+                                Write-Warning "Line $(LINENUM): Unable to download LabtechUpdate.exe version $Version from server $($Svr)."
+                                Continue
+                            } Else {
+                                If ( $PSCmdlet.ShouldProcess($updater, "DownloadFile") ) {
+                                    Write-Debug "Downloading LabtechUpdate.exe from $updater"
+                                    $Script:LTServiceNetWebClient.DownloadFile($updater,"$updaterPath\LabtechUpdate.exe")
+                                    If((Test-Path "$updaterPath\LabtechUpdate.exe") -and  !((Get-Item "$updaterPath\LabtechUpdate.exe" -EA 0).length/1KB -gt 1234)) {
+                                        Write-Warning "Line $(LINENUM): LabtechUpdate.exe size is below normal. Removing suspected corrupt file."
+                                        Remove-Item "$updaterPath\LabtechUpdate.exe" -ErrorAction SilentlyContinue -Force -Confirm:$False
                                         Continue
                                     }#End If
                                 }#End If
-                            }#End Try
-                            Catch {
-                                Write-Warning "Line $(LINENUM): Error encountered downloading $updater."
-                                Continue
-                            }
+    
+                                If ($WhatIfPreference -eq $True) {
+                                    $GoodServer = $Svr
+                                } ElseIf (Test-Path "$updaterPath\LabtechUpdate.exe") {
+                                    $GoodServer = $Svr
+                                    Write-Verbose "LabtechUpdate.exe downloaded successfully from server $($Svr)."
+                                } Else {
+                                    Write-Warning "Line $(LINENUM): Error encountered downloading from $($Svr). No update file was received."
+                                    Continue
+                                }#End If
+                            }#End If
                         }#End Try
                         Catch {
-                            Write-Warning "Line $(LINENUM): Error encountered downloading from $($Svr)."
+                            Write-Warning "Line $(LINENUM): Error encountered downloading $updater."
                             Continue
                         }
-                    } Else {
-                        Write-Warning "Line $(LINENUM): Server address $($Svr) is not formatted correctly. Example: https://lt.domain.com"
+                    }#End Try
+                    Catch {
+                        Write-Warning "Line $(LINENUM): Error encountered downloading from $($Svr)."
+                        Continue
                     }
                 } Else {
-                    Write-Debug "Server $($GoodServer) has been selected."
-                    Write-Verbose "Server has already been selected - Skipping $($Svr)."
+                    Write-Warning "Line $(LINENUM): Server address $($Svr) is not formatted correctly. Example: https://lt.domain.com"
                 }
-            }#End Foreach
-        }#End Process
-
-        End{
-            $detectedVersion = $Settings|Select-Object -Expand 'Version' -EA 0
-            If ($Null -eq $detectedVersion){
-                Write-Error "ERROR: Line $(LINENUM): No existing installation was found." -ErrorAction Stop
-                Return
+            } Else {
+                Write-Debug "Server $($GoodServer) has been selected."
+                Write-Verbose "Server has already been selected - Skipping $($Svr)."
             }
-            If ([System.Version]$detectedVersion -ge [System.Version]$Version) {
-                Write-Warning "Line $(LINENUM): Installed version detected ($detectedVersion) is higher than or equal to the requested version ($Version)."
-                Return
-            }
-            If (-not ($GoodServer)) {
-                Write-Warning "Line $(LINENUM): No valid server was detected."
-                Return
-            }
-            If ([System.Version]$SVer -gt [System.Version]$Version) {
-                Write-Warning "Line $(LINENUM): Server version detected ($SVer) is higher than the requested version ($Version)."
-                Return
-            }
+        }#End Foreach
+    }#End Process
 
-            Try{
-                Stop-LTService
-            }#End Try
-            Catch{
-                Write-Error "ERROR: Line $(LINENUM): There was an error stopping the services. $($Error[0])"
-                return
-            }#End Catch
-    
-            Write-Output "Updating Agent with the following information: Server $($GoodServer), Version $Version"
-            Try{
-                If ($PSCmdlet.ShouldProcess("LabtechUpdate.exe $($xarg)", "Extracting update files")) {
-                    If ((Test-Path "$updaterPath\LabtechUpdate.exe")) {
-                        #Extract Update Files
-                        Write-Verbose "Launching LabtechUpdate Self-Extractor."
-                        Write-Debug "Executing Command ""LabtechUpdate.exe $($xarg)"""
-                        Try {
-                            Push-Location $updaterPath
-                            & "$updaterPath\LabtechUpdate.exe" $($xarg) 2>''
-                            Pop-Location
-                        } 
-                        Catch {Write-Output "Error calling LabtechUpdate.exe."}
-                        Start-Sleep -Seconds 5
-                    } Else {
-                        Write-Verbose "WARNING: $updaterPath\LabtechUpdate.exe was not found."
-                    }
-                }#End If
+    End{
+        $detectedVersion = $Settings|Select-Object -Expand 'Version' -EA 0
+        If ($Null -eq $detectedVersion){
+            Write-Error "ERROR: Line $(LINENUM): No existing installation was found." -ErrorAction Stop
+            Return
+        }
+        If ([System.Version]$detectedVersion -ge [System.Version]$Version) {
+            Write-Warning "Line $(LINENUM): Installed version detected ($detectedVersion) is higher than or equal to the requested version ($Version)."
+            Return
+        }
+        If (-not ($GoodServer)) {
+            Write-Warning "Line $(LINENUM): No valid server was detected."
+            Return
+        }
+        If ([System.Version]$SVer -gt [System.Version]$Version) {
+            Write-Warning "Line $(LINENUM): Server version detected ($SVer) is higher than the requested version ($Version)."
+            Return
+        }
 
-                If ($PSCmdlet.ShouldProcess("Update.exe $($uarg)", "Launching Updater")) {
-                    If ((Test-Path "$updaterPath\Update.exe")) {
-                        #Extract Update Files
-                        Write-Verbose "Launching Labtech Updater"
-                        Write-Debug "Executing Command ""Update.exe $($uarg)"""
-                        Try {& "$updaterPath\Update.exe" $($uarg) 2>''} 
-                        Catch {Write-Output "Error calling Update.exe."}
-                        Start-Sleep -Seconds 5
-                    } Else {
-                        Write-Verbose "WARNING: $updaterPath\Update.exe was not found."
-                    }
-                }#End If
+        Try{
+            Stop-LTService
+        }#End Try
+        Catch{
+            Write-Error "ERROR: Line $(LINENUM): There was an error stopping the services. $($Error[0])"
+            return
+        }#End Catch
 
-            }#End Try
-    
-            Catch{
-                Write-Error "ERROR: Line $(LINENUM): There was an error during the update process $($Error[0])" -ErrorAction Continue
-            }#End Catch
-    
-            Try{
-                Start-LTService
-            }#End Try
-            Catch{
-                Write-Error "ERROR: Line $(LINENUM): There was an error starting the services. $($Error[0])"
-                return
-            }#End Catch
-
-            If ($WhatIfPreference -ne $True) {
-                If ($?) {}
-                Else {$Error[0]}
+        Write-Output "Updating Agent with the following information: Server $($GoodServer), Version $Version"
+        Try{
+            If ($PSCmdlet.ShouldProcess("LabtechUpdate.exe $($xarg)", "Extracting update files")) {
+                If ((Test-Path "$updaterPath\LabtechUpdate.exe")) {
+                    #Extract Update Files
+                    Write-Verbose "Launching LabtechUpdate Self-Extractor."
+                    Write-Debug "Executing Command ""LabtechUpdate.exe $($xarg)"""
+                    Try {
+                        Push-Location $updaterPath
+                        & "$updaterPath\LabtechUpdate.exe" $($xarg) 2>''
+                        Pop-Location
+                    } 
+                    Catch {Write-Output "Error calling LabtechUpdate.exe."}
+                    Start-Sleep -Seconds 5
+                } Else {
+                    Write-Verbose "WARNING: $updaterPath\LabtechUpdate.exe was not found."
+                }
             }#End If
-            Write-Debug "Exiting $($myInvocation.InvocationName) at line $(LINENUM)"
-        }#End End
-    }#End Function Update-LTService
+
+            If ($PSCmdlet.ShouldProcess("Update.exe $($uarg)", "Launching Updater")) {
+                If ((Test-Path "$updaterPath\Update.exe")) {
+                    #Extract Update Files
+                    Write-Verbose "Launching Labtech Updater"
+                    Write-Debug "Executing Command ""Update.exe $($uarg)"""
+                    Try {& "$updaterPath\Update.exe" $($uarg) 2>''} 
+                    Catch {Write-Output "Error calling Update.exe."}
+                    Start-Sleep -Seconds 5
+                } Else {
+                    Write-Verbose "WARNING: $updaterPath\Update.exe was not found."
+                }
+            }#End If
+
+        }#End Try
+
+        Catch{
+            Write-Error "ERROR: Line $(LINENUM): There was an error during the update process $($Error[0])" -ErrorAction Continue
+        }#End Catch
+
+        Try{
+            Start-LTService
+        }#End Try
+        Catch{
+            Write-Error "ERROR: Line $(LINENUM): There was an error starting the services. $($Error[0])"
+            return
+        }#End Catch
+
+        If ($WhatIfPreference -ne $True) {
+            If ($?) {}
+            Else {$Error[0]}
+        }#End If
+        Write-Debug "Exiting $($myInvocation.InvocationName) at line $(LINENUM)"
+    }#End End
+}#End Function Update-LTService
 
 Function Get-LTError{
 <#

--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -648,7 +648,7 @@ Function Uninstall-LTService{
         }
         Foreach ($Svr in $Server) {
             If (-not ($GoodServer)) {
-                If ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*){1,})$') {
+                If ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]+(\.[a-z0-9][a-z0-9_-]*)*)$') {
                     Try{
                         If ($Svr -notmatch 'https?://.+') {$Svr = "http://$($Svr)"}
                         $SvrVerCheck = "$($Svr)/Labtech/Agent.aspx"
@@ -984,14 +984,15 @@ Function Install-LTService{
 
     Begin{
         Clear-Variable DotNET,OSVersion,PasswordArg,Result,logpath,logfile,curlog,installer,installerTest,installerResult,GoodServer,GoodTrayPort,TestTrayPort,Svr,SVer,SvrVer,SvrVerCheck,iarg,timeout,sw,tmpLTSI -EA 0 -WhatIf:$False -Confirm:$False #Clearing Variables for use
-        Write-Debug "Starting $($myInvocation.InvocationName)"
+        Set-Alias -name LINENUM -value Get-CurrentLineNumber -WhatIf:$False -Confirm:$False
+        Write-Debug "Starting $($myInvocation.InvocationName) at line $(LINENUM)"
 
         If (!($Force)) {
             If (Get-Service 'LTService','LTSvcMon' -ErrorAction SilentlyContinue) {
                 If ($WhatIfPreference -ne $True) {
-                    Write-Error "Services are already installed." -ErrorAction Stop
+                    Write-Error "ERROR: Line $(LINENUM): Services are already installed." -ErrorAction Stop
                 } Else {
-                    Write-Error "What if: Stopping: Services are already installed." -ErrorAction Stop
+                    Write-Error "ERROR: Line $(LINENUM): What if: Stopping: Services are already installed." -ErrorAction Stop
                 }#End If
             }#End If
         }#End If
@@ -1018,7 +1019,7 @@ Function Install-LTService{
                         }
                     }
                     catch{
-                        Write-Error "ERROR: .NET 3.5 install failed." -ErrorAction Continue
+                        Write-Error "ERROR: Line $(LINENUM): .NET 3.5 install failed." -ErrorAction Continue
                         if (!($Force)) { Write-Error $Install -ErrorAction Stop }
                     }
                 }
@@ -1032,7 +1033,7 @@ Function Install-LTService{
                             Write-Warning ".Net Framework 3.5 has been installed and enabled." 
                         }
                         Else { 
-                            Write-Error "ERROR: .NET 3.5 install failed." -ErrorAction Continue
+                            Write-Error "ERROR: Line $(LINENUM): .NET 3.5 install failed." -ErrorAction Continue
                             If (!($Force)) { Write-Error $Result -ErrorAction Stop }
                         }#End If
                     }#End If
@@ -1044,12 +1045,12 @@ Function Install-LTService{
             If (-not ($DotNet -like '3.5.*')){
                 If (($Force)) {
                     If ($DotNet -like '2.0.*'){
-                        Write-Error "ERROR: .NET 3.5 is not detected and could not be installed." -ErrorAction Continue
+                        Write-Error "ERROR: Line $(LINENUM): .NET 3.5 is not detected and could not be installed." -ErrorAction Continue
                     } Else {
-                        Write-Error "ERROR: .NET 2.0 is not detected and could not be installed." -ErrorAction Stop
+                        Write-Error "ERROR: Line $(LINENUM): .NET 2.0 is not detected and could not be installed." -ErrorAction Stop
                     }#End If
                 } Else {
-                    Write-Error "ERROR: .NET 3.5 is not detected and could not be installed." -ErrorAction Stop            
+                    Write-Error "ERROR: Line $(LINENUM): .NET 3.5 is not detected and could not be installed." -ErrorAction Stop            
                 }#End If
             }#End If
         }#End If
@@ -1078,7 +1079,7 @@ Function Install-LTService{
         }
         Foreach ($Svr in $Server) {
             If (-not ($GoodServer)) {
-                If ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*){1,})$') {
+                If ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]+(\.[a-z0-9][a-z0-9_-]*)*)$') {
                     If ($Svr -notmatch 'https?://.+') {$Svr = "http://$($Svr)"}
                     Try {
                         $SvrVerCheck = "$($Svr)/Labtech/Agent.aspx"
@@ -1207,7 +1208,7 @@ Function Install-LTService{
                         $svcRun = ('LTService') | Get-Service -EA 0 | Measure-Object | Select-Object -Expand Count
                     } Until ($InstallAttempt -ge 3 -or $svcRun -eq 1)
                     If ($svcRun -eq 0) {
-                        Write-Error "LTService was not installed. Installation failed."
+                        Write-Error "ERROR: Line $(LINENUM): LTService was not installed. Installation failed."
                         return
                     }
                 }#End If
@@ -1255,7 +1256,7 @@ Function Install-LTService{
             }#End Try
 
             Catch{
-                Write-Error "ERROR: There was an error during the install process. $($Error[0])"
+                Write-Error "ERROR: Line $(LINENUM): There was an error during the install process. $($Error[0])"
                 return
             }#End Catch
 
@@ -1265,16 +1266,16 @@ Function Install-LTService{
                     If (($tmpLTSI|Select-Object -Expand 'ID' -EA 0) -gt 1) {
                         Write-Output "LabTech has been installed successfully. Agent ID: $($tmpLTSI|Select-Object -Expand 'ID' -EA 0) LocationID: $($tmpLTSI|Select-Object -Expand 'LocationID' -EA 0)"
                     } ElseIf (!($NoWait)) {
-                        Write-Error "ERROR: LabTech installation completed but Agent failed to register within expected period." -ErrorAction Continue
+                        Write-Error "ERROR: Line $(LINENUM): LabTech installation completed but Agent failed to register within expected period." -ErrorAction Continue
                     } Else {
                         Write-Warning "WARNING: LabTech installation completed but Agent did not yet register." -WarningAction Continue
                     }#End If
                 } Else {
                     If (($Error)) {
-                        Write-Error "ERROR: There was an error installing LabTech. Check the log, $($env:windir)\temp\LabTech\LTAgentInstall.log $($Error[0])"
+                        Write-Error "ERROR: Line $(LINENUM): There was an error installing LabTech. Check the log, $($env:windir)\temp\LabTech\LTAgentInstall.log $($Error[0])"
                         return
                     } ElseIf (!($NoWait)) {
-                        Write-Error "ERROR: There was an error installing LabTech. Check the log, $($env:windir)\temp\LabTech\LTAgentInstall.log"
+                        Write-Error "ERROR: Line $(LINENUM): There was an error installing LabTech. Check the log, $($env:windir)\temp\LabTech\LTAgentInstall.log"
                         return
                     } Else {
                         Write-Warning "WARNING: LabTech installation may not have succeeded." -WarningAction Continue
@@ -1283,9 +1284,9 @@ Function Install-LTService{
             }#End If
             If (($Rename) -and $Rename -notmatch 'False'){ Rename-LTAddRemove -Name $Rename }
         } ElseIf ( $WhatIfPreference -ne $True ) {
-            Write-Error "ERROR: No valid server was reached to use for the install."
+            Write-Error "ERROR: Line $(LINENUM): No valid server was reached to use for the install."
         }#End If
-        Write-Debug "Exiting $($myInvocation.InvocationName)"
+        Write-Debug "Exiting $($myInvocation.InvocationName) at line $(LINENUM)"
     }#End End
 }#End Function Install-LTService
 
@@ -1547,7 +1548,7 @@ Function Update-LTService{
 
             Foreach ($Svr in $Server) {
                 If (-not ($GoodServer)) {
-                    If ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*){1,})$') {
+                    If ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]+(\.[a-z0-9][a-z0-9_-]*)*)$') {
                         If ($Svr -notmatch 'https?://.+') {$Svr = "http://$($Svr)"}
                         Try {
                             $SvrVerCheck = "$($Svr)/Labtech/Agent.aspx"
@@ -2238,7 +2239,7 @@ Function Test-LTPorts{
             )
 
         $RemoteServer = If ([string]::IsNullOrEmpty($ComputerName)) {$IPAddress} Else {$ComputerName};
-        If ([string]::IsNullOrEmpty($RemoteServer)) {Write-Error "No ComputerName or IPAddress was provided to test."; return}
+        If ([string]::IsNullOrEmpty($RemoteServer)) {Write-Error "ERROR: Line $(LINENUM): No ComputerName or IPAddress was provided to test."; return}
 
         $test = New-Object System.Net.Sockets.TcpClient;
         Try
@@ -2260,7 +2261,8 @@ Function Test-LTPorts{
         }#End Function TestPort
 
         Clear-Variable CleanSvr,svr,proc,processes,port,netstat,line -EA 0 -WhatIf:$False -Confirm:$False #Clearing Variables for use
-        Write-Debug "Starting $($myInvocation.InvocationName)"
+        Set-Alias -name LINENUM -value Get-CurrentLineNumber -WhatIf:$False -Confirm:$False
+        Write-Debug "Starting $($myInvocation.InvocationName) at line $(LINENUM)"
 
     }#End Begin
   
@@ -2312,7 +2314,7 @@ Function Test-LTPorts{
                 return
             }
 
-            if ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*){1,})$') {
+            If ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]+(\.[a-z0-9][a-z0-9_-]*)*)$') {
                 Try{
                     $CleanSvr = ($Svr -replace 'https?://',''|ForEach-Object {$_.Trim()})
                     Write-Output "Testing connectivity to required TCP ports:"
@@ -2324,9 +2326,9 @@ Function Test-LTPorts{
                 }#End Try
 
                 Catch{
-                    Write-Error "ERROR: There was an error testing the ports. $($Error[0])" -ErrorAction Stop
+                    Write-Error "ERROR: Line $(LINENUM): There was an error testing the ports. $($Error[0])" -ErrorAction Stop
                 }#End Catch
-            } else {
+            } Else {
                 Write-Warning "Server address $($Svr) is not a valid address or is not formatted correctly. Example: https://lt.domain.com"
             }#End If
         }#End Foreach
@@ -2339,7 +2341,7 @@ Function Test-LTPorts{
             }
         }
         Else{$Error[0]}
-        Write-Debug "Exiting $($myInvocation.InvocationName)"
+        Write-Debug "Exiting $($myInvocation.InvocationName) at line $(LINENUM)"
     }#End End
 }#End Function Test-LTPorts
 
@@ -3199,7 +3201,8 @@ Function Set-LTProxy{
 
     Begin {
         Clear-Variable LTServiceSettingsChanged,LTSS,LTServiceRestartNeeded,proxyURL,proxyUser,proxyPass,passwd,Svr -EA 0 -WhatIf:$False -Confirm:$False #Clearing Variables for use
-        Write-Debug "Starting $($myInvocation.InvocationName)"
+        Set-Alias -name LINENUM -value Get-CurrentLineNumber -WhatIf:$False -Confirm:$False
+        Write-Debug "Starting $($myInvocation.InvocationName) at line $(LINENUM)"
 
         try {
             $LTSS=Get-LTServiceSettings -EA 0 -Verbose:$False -WA 0 -Debug:$False
@@ -3215,11 +3218,11 @@ Function Set-LTProxy{
 ((($ProxyServerURL) -or ($ProxyUsername) -or ($ProxyPassword) -or ($EncodedProxyUsername) -or ($EncodedProxyPassword)) -and (($ResetProxy -eq $True) -or ($DetectProxy -eq $True))) -or 
 ((($ProxyUsername) -or ($ProxyPassword)) -and (-not ($ProxyServerURL) -or ($EncodedProxyUsername) -or ($EncodedProxyPassword) -or ($ResetProxy -eq $True) -or ($DetectProxy -eq $True))) -or 
 ((($EncodedProxyUsername) -or ($EncodedProxyPassword)) -and (-not ($ProxyServerURL) -or ($ProxyUsername) -or ($ProxyPassword) -or ($ResetProxy -eq $True) -or ($DetectProxy -eq $True)))
-        ) {Write-Error "Set-LTProxy: Invalid Parameter specified" -ErrorAction Stop}
+        ) {Write-Error "ERROR: Line $(LINENUM): Set-LTProxy: Invalid Parameter specified" -ErrorAction Stop}
         If (-not (($ResetProxy -eq $True) -or ($DetectProxy -eq $True) -or ($ProxyServerURL) -or ($ProxyUsername) -or ($ProxyPassword) -or ($EncodedProxyUsername) -or ($EncodedProxyPassword))) 
         {
-            If ($Args.Count -gt 0) {Write-Error "Set-LTProxy: Unknown Parameter specified" -ErrorAction Stop}
-            Else {Write-Error "Set-LTProxy: Required Parameters Missing" -ErrorAction Stop}
+            If ($Args.Count -gt 0) {Write-Error "ERROR: Line $(LINENUM): Set-LTProxy: Unknown Parameter specified" -ErrorAction Stop}
+            Else {Write-Error "ERROR: Line $(LINENUM): Set-LTProxy: Required Parameters Missing" -ErrorAction Stop}
         }
 
         Try{
@@ -3242,7 +3245,7 @@ Function Set-LTProxy{
                     $Servers = @($("$($LTSS|Select-Object -Expand 'ServerAddress' -EA 0)|www.connectwise.com").Split('|')|ForEach-Object {$_.Trim()})
                     Foreach ($Svr In $Servers) {
                         If (-not ($Script:LTProxy.Enabled)) {
-                            If ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*){1,})$') {
+                            If ($Svr -match '^(https?://)?(([12]?[0-9]{1,2}\.){3}[12]?[0-9]{1,2}|[a-z0-9][a-z0-9_-]+(\.[a-z0-9][a-z0-9_-]*)*)$') {
                                 $Svr = $Svr -replace 'https?://',''
                                 Try{
                                     $Script:LTProxy.ProxyServerURL=$Script:LTWebProxy.GetProxy("http://$($Svr)").Authority
@@ -3309,7 +3312,7 @@ Function Set-LTProxy{
         }#End Try
     
         Catch{
-            Write-Error "ERROR: There was an error during the Proxy Configuration process. $($Error[0])" -ErrorAction Stop
+            Write-Error "ERROR: Line $(LINENUM): There was an error during the Proxy Configuration process. $($Error[0])" -ErrorAction Stop
         }#End Catch
     }#End Process
 
@@ -3360,7 +3363,7 @@ Function Set-LTProxy{
             }#End If
         }#End If
         Else {$Error[0]}
-        Write-Debug "Exiting $($myInvocation.InvocationName)"
+        Write-Debug "Exiting $($myInvocation.InvocationName) at line $(LINENUM)"
     }#End End
 
 }#End Function Set-LTProxy


### PR DESCRIPTION
I updated to allow single name server names (server vs. server.domain.com) and to accept agent ID 1 as valid (prior test was ID > 1)

The Update-LTService function somehow was all indented one extra tab space, so that's why it shows so many lines replaced.

I tested these changes successfully in my dev environment.