### PR TITLE
Fixes for Get-LTErrors and Get-LTProbeErrors Date handling

### DIFF
--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -1788,7 +1788,7 @@ Function Get-LTError{
 
     Process{
         if ($(Test-Path -Path "$BasePath\LTErrors.txt") -eq $False) {
-            Write-Error "ERROR: Line $(LINENUM): Unable to find log. $($Error[0])"
+            Write-Error "ERROR: Line $(LINENUM): Unable to find log."
             return
         }
         Try{
@@ -2514,7 +2514,7 @@ Function Get-LTProbeErrors{
 
     Process{
         if ($(Test-Path -Path "$BasePath\LTProbeErrors.txt") -eq $False) {
-            Write-Error "ERROR: Line $(LINENUM): Unable to find log. $($Error[0])"
+            Write-Error "ERROR: Line $(LINENUM): Unable to find log."
             return
         }
         $errors = Get-Content "$BasePath\LTProbeErrors.txt"

--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -1744,17 +1744,17 @@ Function Update-LTService{
     }#End End
 }#End Function Update-LTService
 
-Function Get-LTError{
+Function Get-LTErrors{
 <#
 .SYNOPSIS
     This will pull the %ltsvcdir%\LTErrors.txt file into an object.
 
 .EXAMPLE
-    Get-LTError | where {(Get-date $_.Time) -gt (get-date).AddHours(-24)}
+    Get-LTErrors | where {(Get-date $_.Time) -gt (get-date).AddHours(-24)}
     Get a list of all errors in the last 24hr
 
 .EXAMPLE
-    Get-LTError | Out-Gridview
+    Get-LTErrors | Out-Gridview
     Open the log file in a sortable searchable window.
 
 .NOTES
@@ -1771,7 +1771,7 @@ Function Get-LTError{
     Purpose/Change: Changed Erroraction from Stop to unspecified to allow caller to set the ErrorAction.
 
     Update Date: 1/26/2019
-    Purpose/Change: Update for better international date parsing support
+    Purpose/Change: Update for better international date parsing support. Function rename.
 
 .LINK
     http://labtechconsulting.com
@@ -1788,12 +1788,12 @@ Function Get-LTError{
 
     Process{
         if ($(Test-Path -Path "$BasePath\LTErrors.txt") -eq $False) {
-            Write-Error "ERROR: Line $(LINENUM): Unable to find log."
+            Write-Error "ERROR: Line $(LINENUM): Unable to find lelog."
             return
         }
         Try{
             $errors = Get-Content "$BasePath\LTErrors.txt"
-            $errors = $errors -join ' ' -split ':::'
+            $errors = $errors -join ' ' -split '::: '
             foreach($Line in $Errors){
                 $items = $Line -split "`t" -replace ' - ',''
                 if ($items[1]){
@@ -1818,7 +1818,8 @@ Function Get-LTError{
         Else {$Error[0]}
         Write-Debug "Exiting $($myInvocation.InvocationName) at line $(LINENUM)"
     }#End End
-}#End Function Get-LTError
+}#End Function Get-LTErrors
+Set-Alias -Name Get-LTError -Value Get-LTErrors
 
 Function Reset-LTService{
 <#
@@ -2518,7 +2519,7 @@ Function Get-LTProbeErrors{
             return
         }
         $errors = Get-Content "$BasePath\LTProbeErrors.txt"
-        $errors = $errors -join ' ' -split ':::'
+        $errors = $errors -join ' ' -split '::: '
         Try {
             Foreach($Line in $Errors){
                 $items = $Line -split "`t" -replace ' - ',''
@@ -3538,7 +3539,7 @@ Function Initialize-LTServiceModule{
 $PublicFunctions=@(((@"
 ConvertFrom-LTSecurity
 ConvertTo-LTSecurity
-Get-LTError
+Get-LTErrors
 Get-LTLogging
 Get-LTProbeErrors
 Get-LTProxy
@@ -3564,6 +3565,7 @@ Update-LTService
 "@) -replace "[`r`n,\s]+",',') -split ',')
 
 $PublicAlias=@(((@"
+Get-LTError
 ReInstall-LTService
 "@) -replace "[`r`n,\s]+",',') -split ',')
 


### PR DESCRIPTION
Gavin Stone and James Rood have both tested and confirmed this works for international date formats. It still worked fine for me in testing with US date format.

This resolves open issue #38 raised by Gavin.
[(https://github.com/LabtechConsulting/LabTech-Powershell-Module/issues/38)](https://github.com/LabtechConsulting/LabTech-Powershell-Module/issues/38)