### PR TITLE
Fix Uninstall-LtService

### DIFF
--- a/LabTech.psm1
+++ b/LabTech.psm1
@@ -854,6 +854,9 @@ Function Uninstall-LTService{
 
                 If ($PSCmdlet.ShouldProcess("$UninstallBase\$UninstallEXE", "Execute Agent Uninstall")) {
                     If ((Test-Path "$UninstallBase\$UninstallEXE")) {
+                        #Cleanup old Uninstall.exe file. Agent_Uninstall.exe will ask to overwrite if Uninstall.exe file is present.
+                        Remove-Item "$UninstallBase\$UninstallEXEExtracted" -ErrorAction SilentlyContinue -Force -Confirm:$False
+                        Remove-Item "$UninstallBase\$UninstallConfigExtracted" -ErrorAction SilentlyContinue -Force -Confirm:$False
                         #Run $UninstallEXE
                         Write-Verbose "Launching Agent Uninstaller"
                         Write-Debug "Line $(LINENUM): Executing Command ""$UninstallBase\$UninstallEXE"""


### PR DESCRIPTION
Made sure 'Uninstall.exe', 'Uninstall.exe.config' are not present before running Agent_unnstall.exe in the Uninstall-LTService funtion.